### PR TITLE
raise exception when attempting to install from this branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,61 +9,56 @@ Provides easy integration of the  `HAL <https://tools.ietf.org/html/draft-kelly-
 specification for your ``REST`` Flask Applications.
 """
 
+replacement_req = 'pygain-flask-hal = {version = "==1.0.6",index = "fury"}'
+raise Exception(
+    "https://github.com/GainCompliance/Flask-HAL.git@self_attr is deprecated, please change your dependency to {}".format(
+        replacement_req
+    )
+)
+
 # Third Party Libs
 from setuptools import setup
 
 
 # Generate a Long Decription for the PyPi page which is the README.rst
 # Plus the CHANGELOG.rst
-long_description = open('./README.rst').read()
-changelog = open('./CHANGELOG.rst').read()
-long_description += '\n' + changelog
+long_description = open("./README.rst").read()
+changelog = open("./CHANGELOG.rst").read()
+long_description += "\n" + changelog
 
 # Get Version
-version = open('./VERSION.txt').read().strip()
+version = open("./VERSION.txt").read().strip()
 
 
 setup(
-    name='Flask-HAL',
-    url='https://github.com/thisissoon/Flask-HAL',
+    name="Flask-HAL",
+    url="https://github.com/thisissoon/Flask-HAL",
     version=version,
-    author='SOON_',
-    author_email='dorks@thisissoon.com',
-    description='Provides easy integration of the HAL specification for '
-                'your REST Flask Applications.',
+    author="SOON_",
+    author_email="dorks@thisissoon.com",
+    description="Provides easy integration of the HAL specification for " "your REST Flask Applications.",
     long_description=long_description,
-    packages=[
-        'flask_hal',
-    ],
-    install_requires=[
-        'flask',
-    ],
-    tests_require=[
-        'pytest',
-        'pytest_cov',
-        'pytest_pep8',
-        'pytest-flakes',
-    ],
-    setup_requires=[
-        'pytest-runner',
-    ],
+    packages=["flask_hal"],
+    install_requires=["flask"],
+    tests_require=["pytest", "pytest_cov", "pytest_pep8", "pytest-flakes"],
+    setup_requires=["pytest-runner"],
     classifiers=[
-        'Framework :: Flask',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Development Status :: 5 - Production/Stable',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Topic :: Software Development',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'License :: Public Domain'
+        "Framework :: Flask",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Development Status :: 5 - Production/Stable",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        "License :: Public Domain",
     ],
-    license='Public Domain',
-    keywords=['Flask', 'HAL', 'REST', 'Views']
+    license="Public Domain",
+    keywords=["Flask", "HAL", "REST", "Views"],
 )


### PR DESCRIPTION
context:
the pipenv install process we use runs `pipenv lock --keep-outdated -r > ./requirements.txt` and then a `pip install -r requirements.txt`. Currently we are installing Flask-HAL from a branch on this fork with something like 
```
Flask-HAL = {git = "https://github.com/GainCompliance/Flask-HAL.git",ref = "self_attr"}
```
in the `Pipfile`

I have occasionally seen local installs fail with an error during the `pip install -r requirements.txt` with this message in the terminal
```
ERROR: Invalid requirement: "Switched to a new branch 'self_attr'" (from line 1 of ./requirements.txt)
```
This comes from `pipenv lock > ./requirements.txt` not properly filtering the stdout during the git process of downloading the repo and switching to the branch when installing.

In the past this issue has been intermittent and subsequent installs don't seem to have the issue. During the work on converting document-api to python3, this issue started to present in CI for unknown reasons and was completely blocking install. To work around it, I created a new repo https://github.com/GainCompliance/pygain-flask-hal based on this branch, gutted the CI/development config and rebuilt it to publish on gemfury. 

Merging this PR will make all builds fail when they attempt to install from the `self_attr` branch with a message to update dependencies in `Pipfile`. Is this something we want to do? Should we do it now and just force update, or should I manually update all of the repos first?